### PR TITLE
Adds support for accessToken in config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-node_modules

--- a/index.js
+++ b/index.js
@@ -39,18 +39,20 @@ Auth.prototype.getAuthClient = function (callback) {
     return;
   }
 
-  var googleAuth = new GoogleAuth();
+  if (!config.accessToken) {
+    var googleAuth = new GoogleAuth();
 
-  if (config.keyFilename || config.keyFile) {
-    var authClient = new googleAuth.JWT();
-    authClient.keyFile = config.keyFilename || config.keyFile;
-    authClient.email = config.email;
-    authClient.scopes = config.scopes;
-    addScope(null, authClient);
-  } else if (config.credentials) {
-    googleAuth.fromJSON(config.credentials, addScope);
-  } else {
-    googleAuth.getApplicationDefault(addScope);
+    if (config.keyFilename || config.keyFile) {
+      var authClient = new googleAuth.JWT();
+      authClient.keyFile = config.keyFilename || config.keyFile;
+      authClient.email = config.email;
+      authClient.scopes = config.scopes;
+      addScope(null, authClient);
+    } else if (config.credentials) {
+      googleAuth.fromJSON(config.credentials, addScope);
+    } else {
+      googleAuth.getApplicationDefault(addScope);
+    }
   }
 
   function addScope(err, authClient) {
@@ -109,6 +111,10 @@ Auth.prototype.getCredentials = function (callback) {
 };
 
 Auth.prototype.getToken = function (callback) {
+  if (this.config.accessToken) {
+    callback(null, this.config.accessToken)
+  }
+
   this.getAuthClient(function (err, client) {
     if (err) {
       callback(err);

--- a/test.js
+++ b/test.js
@@ -376,5 +376,16 @@ describe('googleAutoAuth', function () {
 
       auth.getToken(done);
     });
+
+    it('should immediately return an access token if one is configured', function(done) {
+      auth.config = {
+        accessToken: 'immediate_token'
+      };
+
+      auth.getToken(function(err, token) {
+        assert.strictEqual(token, 'immediate_token');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
There are situations where an application will already have an access token ([see issue](https://github.com/GoogleCloudPlatform/gcloud-node/issues/1346)). In my case, I have a command-line client that uses an OAuth flow to gain credentials instead of a service account.

This PR adds support for `config.accessToken` which, if specified, will short-circuit the more complex behavior and simply return the token provided. This will allow gcloud to support access token based authentication.
