### PR TITLE
support apikey from google-auth-library

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ Auth.prototype.authorizeRequest = function (reqOpts, callback) {
 
 Auth.prototype.getAuthClient = function (callback) {
   var self = this;
-  var config = self.config;
+  var config = this.config;
 
   if (this.authClient) {
     setImmediate(function () {
@@ -59,6 +59,8 @@ Auth.prototype.getAuthClient = function (callback) {
     authClient.keyFile = keyFile;
     authClient.email = config.email;
     addScope(null, authClient);
+  } else if (config.apiKey) {
+    googleAuth.fromAPIKey(config.apiKey, addScope);
   } else {
     googleAuth.getApplicationDefault(addScope);
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "^2.1.2",
-    "google-auth-library": "^0.9.10",
+    "google-auth-library": "^0.11.0",
     "object-assign": "^3.0.0",
     "request": "^2.79.0"
   }

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Everything from the [gcloud-node Authentication Guide](https://googlecloudplatfo
 
 At a glance, the supported properties for this method are:
 
+- `apiKey` - An API key
 - `keyFilename` - Path to a .json, .pem, or .p12 key file
 - `credentials` - Object containing `client_email` and `private_key` properties
 - `scopes` - Required scopes for the desired API request
@@ -263,6 +264,3 @@ We won't return an error, but it's here for convention-sake.
 - Type: `Boolean`
 
 Whether the app is in a Compute Engine instance or not.
-
-
-

--- a/test.js
+++ b/test.js
@@ -223,6 +223,38 @@ describe('googleAutoAuth', function () {
       });
     });
 
+    it('should create an auth client from an API key', function (done) {
+      var googleAuthClient = {
+        createScopedRequired: function () {}
+      };
+      var projectId = 'project-id';
+
+      googleAuthLibraryOverride = function () {
+        return {
+          fromAPIKey: function (apiKey, callback) {
+            assert.deepEqual(apiKey, auth.config.apiKey);
+
+            callback(null, googleAuthClient, projectId);
+          }
+        };
+      };
+
+      auth.config = {
+        apiKey: 'api-key'
+      };
+
+      auth.getAuthClient(function (err, authClient) {
+        assert.ifError(err);
+
+        assert.strictEqual(auth.projectId, projectId);
+
+        assert.strictEqual(auth.authClient, googleAuthClient);
+        assert.strictEqual(authClient, googleAuthClient);
+
+        done();
+      });
+    });
+
     it('should create an auth client from magic', function (done) {
       var googleAuthClient = {
         createScopedRequired: function () {}


### PR DESCRIPTION
Fixes #9

## Blocked

**A new release of google-auth-library with API Key support is required.**

---

This PR adds support for getting an auth client from just an API Key:

```js
var authClient = require('google-auto-auth')({ apiKey: '...' })
```