### PR TITLE
cache authClient across concurrent requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 node_modules
 coverage
 *.log

--- a/test.js
+++ b/test.js
@@ -94,7 +94,7 @@ describe('googleAutoAuth', function () {
   });
 
   describe('getAuthClient', function () {
-    beforeEach(function() {
+    beforeEach(function () {
       process.chdir(__dirname);
     });
 
@@ -113,7 +113,7 @@ describe('googleAutoAuth', function () {
       });
     });
 
-    it('should re-use an existing authClientPromise', function(done) {
+    it('should re-use an existing authClientPromise', function (done) {
       auth.authClientPromise = Promise.resolve(42);
 
       auth.getAuthClient(function (err, authClient) {

--- a/test.js
+++ b/test.js
@@ -103,10 +103,13 @@ describe('googleAutoAuth', function () {
 
       auth.getAuthClient(function (err, authClient) {
         assert.strictEqual(authClient, auth.authClient);
-        auth.authClientPromise.then(function(authClientFromPromise) {
-          assert.strictEqual(authClientFromPromise, authClient);
-        });
-        done();
+
+        auth.authClientPromise
+          .then(function (authClientFromPromise) {
+            assert.strictEqual(authClientFromPromise, authClient);
+            done();
+          })
+          .catch(done);
       });
     });
 
@@ -114,6 +117,7 @@ describe('googleAutoAuth', function () {
       auth.authClientPromise = Promise.resolve(42);
 
       auth.getAuthClient(function (err, authClient) {
+        assert.ifError(err);
         assert.strictEqual(authClient, 42);
         done();
       });


### PR DESCRIPTION
If multiple calls to `getAuthClient` are made concurrently before we can initialize the `authClient`, we end up with multiple `authClient` objects initialized in parallel. Use a promise as a better cache to avoid unnecessary work.