### PR TITLE
Update gcp-metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "^2.1.2",
-    "gcp-metadata": "^0.1.0",
+    "gcp-metadata": "^0.2.0",
     "google-auth-library": "^0.10.0",
     "object-assign": "^3.0.0",
     "request": "^2.79.0"


### PR DESCRIPTION
As this lib is already `"request": "^2.79.0"`, it's not breaking, is it?