### PR TITLE
require Node >= 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var assign = require('object-assign');
 var async = require('async');
 var fs = require('fs');
 var GoogleAuth = require('google-auth-library');
@@ -26,9 +25,11 @@ Auth.prototype.authorizeRequest = function (reqOpts, callback) {
       return;
     }
 
-    var authorizedReqOpts = assign({}, reqOpts);
-    authorizedReqOpts.headers = authorizedReqOpts.headers || {};
-    authorizedReqOpts.headers.Authorization = 'Bearer ' + token;
+    var authorizedReqOpts = Object.assign({}, reqOpts, {
+      headers: Object.assign({}, reqOpts.headers, {
+        Authorization: `Bearer ${token}`
+      })
+    });
 
     callback(null, authorizedReqOpts);
   });

--- a/index.js
+++ b/index.js
@@ -7,226 +7,226 @@ var gcpMetadata = require('gcp-metadata');
 var path = require('path');
 var request = require('request');
 
-function Auth(config) {
-  if (!(this instanceof Auth)) {
-    return new Auth(config);
+class Auth {
+  constructor(config) {
+    this.authClientPromise = null;
+    this.authClient = null;
+    this.config = config || {};
+    this.environment = {};
   }
 
-  this.authClientPromise = null;
-  this.authClient = null;
-  this.config = config || {};
-  this.environment = {};
-}
-
-Auth.prototype.authorizeRequest = function (reqOpts, callback) {
-  this.getToken((err, token) => {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    var authorizedReqOpts = Object.assign({}, reqOpts, {
-      headers: Object.assign({}, reqOpts.headers, {
-        Authorization: `Bearer ${token}`
-      })
-    });
-
-    callback(null, authorizedReqOpts);
-  });
-};
-
-Auth.prototype.getAuthClient = function (callback) {
-  var createAuthClientPromise = (resolve, reject) => {
-    var googleAuth = new GoogleAuth();
-
-    var config = this.config;
-    var keyFile = config.keyFilename || config.keyFile;
-
-    var addScope = (err, authClient, projectId) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-
-      if (authClient.createScopedRequired && authClient.createScopedRequired()) {
-        if (!config.scopes || config.scopes.length === 0) {
-          var scopeError = new Error('Scopes are required for this request.');
-          scopeError.code = 'MISSING_SCOPE';
-          reject(scopeError);
-          return;
-        }
-      }
-
-      authClient.scopes = config.scopes;
-      this.authClient = authClient;
-      this.projectId = projectId || authClient.projectId;
-
-      resolve(authClient);
-    };
-
-    if (config.credentials) {
-      googleAuth.fromJSON(config.credentials, addScope);
-    } else if (keyFile) {
-      keyFile = path.resolve(process.cwd(), keyFile);
-
-      fs.readFile(keyFile, (err, contents) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-
-        try {
-          googleAuth.fromJSON(JSON.parse(contents), addScope);
-        } catch(e) {
-          var authClient = new googleAuth.JWT();
-          authClient.keyFile = keyFile;
-          authClient.email = config.email;
-          addScope(null, authClient);
-        }
-      });
-    } else {
-      googleAuth.getApplicationDefault(addScope);
-    }
-  };
-
-  if (!this.authClientPromise) {
-    if (this.authClient) {
-      this.authClientPromise = Promise.resolve(this.authClient);
-    } else {
-      this.authClientPromise = new Promise(createAuthClientPromise);
-    }
-  }
-
-  this.authClientPromise.then(callback.bind(null, null)).catch(callback);
-};
-
-Auth.prototype.getCredentials = function (callback) {
-  this.getAuthClient((err, client) => {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    if (client.email && client.key) {
-      callback(null, {
-        client_email: client.email,
-        private_key: client.key
-      });
-      return;
-    }
-
-    if (!client.authorize) {
-      callback(new Error('Could not get credentials without a JSON, pem, or p12 keyfile.'));
-      return;
-    }
-
-    client.authorize(err => {
+  authorizeRequest (reqOpts, callback) {
+    this.getToken((err, token) => {
       if (err) {
         callback(err);
         return;
       }
 
-      this.getCredentials(callback);
+      var authorizedReqOpts = Object.assign({}, reqOpts, {
+        headers: Object.assign({}, reqOpts.headers, {
+          Authorization: `Bearer ${token}`
+        })
+      });
+
+      callback(null, authorizedReqOpts);
     });
-  });
-};
+  }
 
-Auth.prototype.getEnvironment = function (callback) {
-  async.parallel([
-    cb => this.isAppEngine(cb),
-    cb => this.isCloudFunction(cb),
-    cb => this.isComputeEngine(cb),
-    cb => this.isContainerEngine(cb)
-  ], () => {
-    callback(null, this.environment);
-  });
-};
+  getAuthClient (callback) {
+    var createAuthClientPromise = (resolve, reject) => {
+      var googleAuth = new GoogleAuth();
 
-Auth.prototype.getProjectId = function (callback) {
-  if (this.projectId) {
-    setImmediate(() => {
+      var config = this.config;
+      var keyFile = config.keyFilename || config.keyFile;
+
+      var addScope = (err, authClient, projectId) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+          if (!config.scopes || config.scopes.length === 0) {
+            var scopeError = new Error('Scopes are required for this request.');
+            scopeError.code = 'MISSING_SCOPE';
+            reject(scopeError);
+            return;
+          }
+        }
+
+        authClient.scopes = config.scopes;
+        this.authClient = authClient;
+        this.projectId = projectId || authClient.projectId;
+
+        resolve(authClient);
+      };
+
+      if (config.credentials) {
+        googleAuth.fromJSON(config.credentials, addScope);
+      } else if (keyFile) {
+        keyFile = path.resolve(process.cwd(), keyFile);
+
+        fs.readFile(keyFile, (err, contents) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          try {
+            googleAuth.fromJSON(JSON.parse(contents), addScope);
+          } catch(e) {
+            var authClient = new googleAuth.JWT();
+            authClient.keyFile = keyFile;
+            authClient.email = config.email;
+            addScope(null, authClient);
+          }
+        });
+      } else {
+        googleAuth.getApplicationDefault(addScope);
+      }
+    };
+
+    if (!this.authClientPromise) {
+      if (this.authClient) {
+        this.authClientPromise = Promise.resolve(this.authClient);
+      } else {
+        this.authClientPromise = new Promise(createAuthClientPromise);
+      }
+    }
+
+    this.authClientPromise.then(callback.bind(null, null)).catch(callback);
+  }
+
+  getCredentials (callback) {
+    this.getAuthClient((err, client) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      if (client.email && client.key) {
+        callback(null, {
+          client_email: client.email,
+          private_key: client.key
+        });
+        return;
+      }
+
+      if (!client.authorize) {
+        callback(new Error('Could not get credentials without a JSON, pem, or p12 keyfile.'));
+        return;
+      }
+
+      client.authorize(err => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        this.getCredentials(callback);
+      });
+    });
+  }
+
+  getEnvironment (callback) {
+    async.parallel([
+      cb => this.isAppEngine(cb),
+      cb => this.isCloudFunction(cb),
+      cb => this.isComputeEngine(cb),
+      cb => this.isContainerEngine(cb)
+    ], () => {
+      callback(null, this.environment);
+    });
+  }
+
+  getProjectId (callback) {
+    if (this.projectId) {
+      setImmediate(() => {
+        callback(null, this.projectId);
+      });
+      return;
+    }
+
+    this.getAuthClient(err => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
       callback(null, this.projectId);
     });
-    return;
   }
 
-  this.getAuthClient(err => {
-    if (err) {
-      callback(err);
-      return;
-    }
+  getToken (callback) {
+    this.getAuthClient((err, client) => {
+      if (err) {
+        callback(err);
+        return;
+      }
 
-    callback(null, this.projectId);
-  });
-};
+      client.getAccessToken(callback);
+    });
+  }
 
-Auth.prototype.getToken = function (callback) {
-  this.getAuthClient((err, client) => {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    client.getAccessToken(callback);
-  });
-};
-
-Auth.prototype.isAppEngine = function (callback) {
-  setImmediate(() => {
-    var env = this.environment;
-
-    if (typeof env.IS_APP_ENGINE === 'undefined') {
-      env.IS_APP_ENGINE = !!(process.env.GAE_SERVICE || process.env.GAE_MODULE_NAME);
-    }
-
-    callback(null, env.IS_APP_ENGINE);
-  });
-};
-
-Auth.prototype.isCloudFunction = function (callback) {
-  setImmediate(() => {
-    var env = this.environment;
-
-    if (typeof env.IS_CLOUD_FUNCTION === 'undefined') {
-      env.IS_CLOUD_FUNCTION = !!process.env.FUNCTION_NAME;
-    }
-
-    callback(null, env.IS_CLOUD_FUNCTION);
-  });
-};
-
-Auth.prototype.isComputeEngine = function (callback) {
-  var env = this.environment;
-
-  if (typeof env.IS_COMPUTE_ENGINE !== 'undefined') {
+  isAppEngine (callback) {
     setImmediate(() => {
+      var env = this.environment;
+
+      if (typeof env.IS_APP_ENGINE === 'undefined') {
+        env.IS_APP_ENGINE = !!(process.env.GAE_SERVICE || process.env.GAE_MODULE_NAME);
+      }
+
+      callback(null, env.IS_APP_ENGINE);
+    });
+  }
+
+  isCloudFunction (callback) {
+    setImmediate(() => {
+      var env = this.environment;
+
+      if (typeof env.IS_CLOUD_FUNCTION === 'undefined') {
+        env.IS_CLOUD_FUNCTION = !!process.env.FUNCTION_NAME;
+      }
+
+      callback(null, env.IS_CLOUD_FUNCTION);
+    });
+  }
+
+  isComputeEngine (callback) {
+    var env = this.environment;
+
+    if (typeof env.IS_COMPUTE_ENGINE !== 'undefined') {
+      setImmediate(() => {
+        callback(null, env.IS_COMPUTE_ENGINE);
+      });
+      return;
+    }
+
+    request('http://metadata.google.internal', (err, res) => {
+      env.IS_COMPUTE_ENGINE = !err && res.headers['metadata-flavor'] === 'Google';
+
       callback(null, env.IS_COMPUTE_ENGINE);
     });
-    return;
   }
 
-  request('http://metadata.google.internal', (err, res) => {
-    env.IS_COMPUTE_ENGINE = !err && res.headers['metadata-flavor'] === 'Google';
+  isContainerEngine (callback) {
+    var env = this.environment;
 
-    callback(null, env.IS_COMPUTE_ENGINE);
-  });
-};
+    if (typeof env.IS_CONTAINER_ENGINE !== 'undefined') {
+      setImmediate(() => {
+        callback(null, env.IS_CONTAINER_ENGINE);
+      });
+      return;
+    }
 
-Auth.prototype.isContainerEngine = function (callback) {
-  var env = this.environment;
+    gcpMetadata.instance('/attributes/cluster-name', err => {
+      env.IS_CONTAINER_ENGINE = !err;
 
-  if (typeof env.IS_CONTAINER_ENGINE !== 'undefined') {
-    setImmediate(() => {
       callback(null, env.IS_CONTAINER_ENGINE);
     });
-    return;
   }
+}
 
-  gcpMetadata.instance('/attributes/cluster-name', err => {
-    env.IS_CONTAINER_ENGINE = !err;
-
-    callback(null, env.IS_CONTAINER_ENGINE);
-  });
+module.exports = config => {
+  return new Auth(config);
 };
-
-module.exports = Auth;

--- a/package.json
+++ b/package.json
@@ -29,14 +29,16 @@
   "repository": "stephenplusplus/google-auto-auth",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^2.2.5",
-    "mockery": "^1.4.0"
+    "mocha": "^3.3.0",
+    "mockery": "^2.0.0"
   },
   "dependencies": {
-    "async": "^2.1.2",
+    "async": "^2.3.0",
     "gcp-metadata": "^0.2.0",
     "google-auth-library": "^0.10.0",
-    "object-assign": "^3.0.0",
     "request": "^2.79.0"
+  },
+  "engines": {
+    "node": ">=0.4.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var assert = require('assert');
-var assign = require('object-assign');
 var fs = require('fs');
 var googleAuthLibrary = require('google-auth-library');
 var mockery = require('mockery');
@@ -50,7 +49,7 @@ describe('googleAutoAuth', function () {
   beforeEach(function () {
     requestOverride = null;
     googleAuthLibraryOverride = null;
-    instanceOverride = null
+    instanceOverride = null;
     auth = googleAutoAuth();
   });
 
@@ -87,10 +86,10 @@ describe('googleAutoAuth', function () {
         }
       };
 
-      var expectedAuthorizedReqOpts = assign({}, reqOpts);
-      expectedAuthorizedReqOpts.headers = assign(reqOpts.headers, {
-        Authorization: 'Bearer ' + token
-      });
+      var expectedAuthorizedReqOpts = Object.assign({}, reqOpts);
+      expectedAuthorizedReqOpts.headers = Object.assign({
+        Authorization: `Bearer ${token}`
+      }, reqOpts.headers);
 
       auth.getToken = function (callback) {
         callback(null, token);
@@ -98,6 +97,8 @@ describe('googleAutoAuth', function () {
 
       auth.authorizeRequest(reqOpts, function (err, authorizedReqOpts) {
         assert.ifError(err);
+        assert.notStrictEqual(authorizedReqOpts, reqOpts);
+        assert.notDeepEqual(authorizedReqOpts, reqOpts);
         assert.deepEqual(authorizedReqOpts, expectedAuthorizedReqOpts);
         done();
       });
@@ -265,7 +266,7 @@ describe('googleAutoAuth', function () {
         keyFilename: 'non-existent-key.pem'
       };
 
-      auth.getAuthClient(function (err, authClient) {
+      auth.getAuthClient(function (err) {
         assert(err.message.includes('no such file or directory'));
         done();
       });
@@ -734,7 +735,7 @@ describe('googleAutoAuth', function () {
     });
 
     it('should make the correct metadata lookup', function (done) {
-      instanceOverride = function (property, callback) {
+      instanceOverride = function (property) {
         assert.strictEqual(property, '/attributes/cluster-name');
         done();
       };


### PR DESCRIPTION
This PR changes our implicit dependency on Node * to explicitly depending on Node >= 4. It will require a semver-major bump to 0.7.0.

In this PR:

- Bump Node support to >= 4
- Remove `object-assign` dependency and use Object.assign instead
- Update dependencies
- Small lint fixes

@SimenB would you mind taking a look to make sure I didn't gloss over anything?