### PR TITLE
feat: provide clusterName when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,9 +239,9 @@ class Auth {
       return;
     }
 
-    gcpMetadata.instance('/attributes/cluster-name', err => {
+    gcpMetadata.instance('/attributes/cluster-name', (err, _, clusterName) => {
       env.IS_CONTAINER_ENGINE = !err;
-
+      env.clusterName = clusterName;
       callback(null, env.IS_CONTAINER_ENGINE);
     });
   }

--- a/test.js
+++ b/test.js
@@ -749,10 +749,12 @@ describe('googleAutoAuth', function () {
       };
 
       assert.strictEqual(auth.environment.IS_CONTAINER_ENGINE, undefined);
+      assert.strictEqual(auth.environment.clusterName, undefined);
 
       auth.isContainerEngine(function (err, isContainerEngine) {
         assert.ifError(err);
         assert.strictEqual(auth.environment.IS_CONTAINER_ENGINE, false);
+        assert.strictEqual(auth.environment.clusterName, undefined);
         assert.strictEqual(isContainerEngine, false);
         done();
       });
@@ -760,14 +762,16 @@ describe('googleAutoAuth', function () {
 
     it('should set true if instance request succeeds', function (done) {
       instanceOverride = function (property, callback) {
-        callback(null);
+        callback(null, null, 'fake-cluster');
       };
 
       assert.strictEqual(auth.environment.IS_CONTAINER_ENGINE, undefined);
+      assert.strictEqual(auth.environment.clusterName, undefined);
 
       auth.isContainerEngine(function (err, isContainerEngine) {
         assert.ifError(err);
         assert.strictEqual(auth.environment.IS_CONTAINER_ENGINE, true);
+        assert.strictEqual(auth.environment.clusterName, 'fake-cluster');
         assert.strictEqual(isContainerEngine, true);
         done();
       });


### PR DESCRIPTION
isContainerEngine is already acquiring the clusterName when running on
GKE. Provide this value on the environment.