### PR TITLE
test: fix re-use existing authClient test

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,11 +107,7 @@ class Auth {
     };
 
     if (!this.authClientPromise) {
-      if (this.authClient) {
-        this.authClientPromise = Promise.resolve(this.authClient);
-      } else {
-        this.authClientPromise = new Promise(createAuthClientPromise);
-      }
+      this.authClientPromise = new Promise(createAuthClientPromise);
     }
 
     this.authClientPromise.then(callback.bind(null, null)).catch(callback);

--- a/test.js
+++ b/test.js
@@ -129,23 +129,25 @@ describe('googleAutoAuth', function () {
       });
     });
 
-    it('should create an authClientPromise', function(done) {
-      const AUTH_CLIENT = { x: 'x', y: 'y'};
+    it('should create an authClientPromise', function (done) {
+      var authClient = {};
 
       googleAuthLibraryOverride = function () {
         return {
-          getApplicationDefault: function (cb) {
-            cb(null, AUTH_CLIENT);
+          getApplicationDefault: function (callback) {
+            callback(null, authClient);
           }
         };
       };
 
-      auth.getAuthClient(function (err, authClient) {
+      auth.getAuthClient(function (err, _authClient) {
         assert.ifError(err);
-        assert.strictEqual(authClient, AUTH_CLIENT);
+
+        assert.strictEqual(_authClient, authClient);
+
         auth.authClientPromise
           .then(function (authClientFromPromise) {
-            assert.strictEqual(authClientFromPromise, AUTH_CLIENT);
+            assert.strictEqual(authClientFromPromise, authClient);
             done();
           });
       });

--- a/test.js
+++ b/test.js
@@ -115,13 +115,7 @@ describe('googleAutoAuth', function () {
 
       auth.getAuthClient(function (err, authClient) {
         assert.strictEqual(authClient, auth.authClient);
-
-        auth.authClientPromise
-          .then(function (authClientFromPromise) {
-            assert.strictEqual(authClientFromPromise, authClient);
-            done();
-          })
-          .catch(done);
+        done();
       });
     });
 

--- a/test.js
+++ b/test.js
@@ -129,6 +129,28 @@ describe('googleAutoAuth', function () {
       });
     });
 
+    it('should create an authClientPromise', function(done) {
+      const AUTH_CLIENT = { x: 'x', y: 'y'};
+
+      googleAuthLibraryOverride = function () {
+        return {
+          getApplicationDefault: function (cb) {
+            cb(null, AUTH_CLIENT);
+          }
+        };
+      };
+
+      auth.getAuthClient(function (err, authClient) {
+        assert.ifError(err);
+        assert.strictEqual(authClient, AUTH_CLIENT);
+        auth.authClientPromise
+          .then(function (authClientFromPromise) {
+            assert.strictEqual(authClientFromPromise, AUTH_CLIENT);
+            done();
+          });
+      });
+    });
+
     it('should use google-auth-library', function () {
       var googleAuthLibraryCalled = false;
 


### PR DESCRIPTION
I believe this got broken by https://github.com/stephenplusplus/google-auto-auth/pull/21.