### PR TITLE
Accept and cache project ID.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class Auth {
     this.config = config || {};
     this.credentials = null;
     this.environment = {};
+    this.projectId = this.config.projectId;
   }
 
   authorizeRequest (reqOpts, callback) {
@@ -79,7 +80,7 @@ class Auth {
 
         authClient.scopes = config.scopes;
         this.authClient = authClient;
-        this.projectId = projectId || authClient.projectId;
+        this.projectId = config.projectId || projectId || authClient.projectId;
 
         resolve(authClient);
       };

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ At a glance, the supported properties for this method are:
 - `keyFilename` - Path to a .json, .pem, or .p12 key file
 - `credentials` - Object containing `client_email` and `private_key` properties
 - `scopes` - Required scopes for the desired API request
+- `projectId` - Your project ID.
 
 For more details, see the Authentication Guide linked above, under "The config object".
 

--- a/test.js
+++ b/test.js
@@ -62,6 +62,33 @@ describe('googleAutoAuth', function () {
     auth = googleAutoAuth();
   });
 
+  describe('constructor', function () {
+    it('should set correct defaults', function () {
+      assert.strictEqual(auth.authClientPromise, null);
+      assert.strictEqual(auth.authClient, null);
+      assert.strictEqual(auth.googleAuthClient, null);
+      assert.deepStrictEqual(auth.config, {});
+      assert.strictEqual(auth.credentials, null);
+      assert.deepStrictEqual(auth.environment, {});
+      assert.strictEqual(auth.projectId, undefined);
+    });
+
+    it('should cache config', function () {
+      var config = {};
+      var auth = googleAutoAuth(config);
+
+      assert.strictEqual(auth.config, config);
+    });
+
+    it('should cache project ID', function () {
+      var auth = googleAutoAuth({
+        projectId: 'project-id'
+      });
+
+      assert.strictEqual(auth.projectId, 'project-id');
+    });
+  });
+
   describe('authorizeRequest', function () {
     it('should get a token', function (done) {
       auth.getToken = function () {
@@ -295,6 +322,33 @@ describe('googleAutoAuth', function () {
         assert.strictEqual(auth.authClient, googleAuthClient);
         assert.strictEqual(authClient, googleAuthClient);
 
+        done();
+      });
+    });
+
+    it('should prefer the user-provided project ID', function (done) {
+      var googleAuthClient = {
+        createScopedRequired: function () {}
+      };
+      var badProjectId = 'bad-project-id';
+      var goodProjectId = 'good-project-id';
+
+      googleAuthLibraryOverride = function () {
+        return {
+          fromJSON: function (json, callback) {
+            callback(null, googleAuthClient, badProjectId);
+          }
+        };
+      };
+
+      auth.config = {
+        projectId: goodProjectId,
+        credentials: { a: 'b', c: 'd' }
+      };
+
+      auth.getAuthClient(function (err, authClient) {
+        assert.ifError(err);
+        assert.strictEqual(auth.projectId, goodProjectId);
         done();
       });
     });


### PR DESCRIPTION
This is part 1/2 of a resolution for https://github.com/googleapis/nodejs-datastore/issues/27

This PR allows users to provide their own project ID. This will be preferred over one that is detected by google-auth-library (which sometimes, might not detect anything).